### PR TITLE
[J] kakaopage 2주차 PR1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.DS_Store
+node_modules/
+package-lock.json

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -406,6 +406,10 @@
     width: 100%;
 }
 
+.banner .slider_items.animate {
+    transition: .3s;
+}
+
 .banner .slider_items .item {
     width: 100%;
     flex-shrink: 0;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -174,6 +174,7 @@
 }
 
 .item .info_txt.viewer {
+    flex-shrink: 0;
     padding-left: 15px;
     background: url(../images/ico/icon_read_count.png) no-repeat left center / 11px 11px;
 }
@@ -381,6 +382,7 @@
 
 .item_type3 .txt .item_desc {
     margin-top: 7px;
+    min-height: 1em;
 }
 
 /* banner */

--- a/assets/js/data.js
+++ b/assets/js/data.js
@@ -217,4 +217,203 @@ const topBanner = {
     ],
 }
 
-export {topBanner}
+const webtoonData = [
+    {
+        title : "학사재생",
+        description : "금수저를 물고 태어나 버렸다!",
+        image : "https://dn-img-page.kakao.com/download/resource?kid=B9yif/hyoXEYHVNL/gMonAbOI5FKnlnRpgUvmR0&filename=th2",
+        badge : {
+            up : true,
+            new : false,
+            age15 : false
+        },
+        week : "mon",
+        viewer : "167.2만명",
+        class : "crown",
+        writer : "소유현, 윰짝짝"
+    },
+    {
+        title : "후궁계약",
+        description : "후궁으로 입궁해 다오. 그게 내 의뢰다.",
+        image : "https://dn-img-page.kakao.com/download/resource?kid=coL2BT/hzb7AO2NDX/kUIOK8kQUGSR1jVL7R9Sx0&filename=th2",
+        badge : {
+            up : true,
+            new : false,
+            age15 : false
+        },
+        week : "mon",
+        viewer : "93.7만명",
+        writer : "소유현, 윰짝짝"
+    },
+    {
+        title : "그 책에 마음을 주지 마세요",
+        description : "우연히 주운 일기장이 미래를 예지한다.",
+        image : "https://dn-img-page.kakao.com/download/resource?kid=4i2ND/hy41JLoVim/MEkdJfaKxe99QY1C20PExk&filename=th2",
+        badge : {
+            up : false,
+            new : false,
+            age15 : false
+        },
+        week : "mon",
+        viewer : "35.6.7만명",
+        writer : "문시현, 임조조"
+    },
+    {
+        title : "프로야구생존기",
+        description : "노영웅의 프로야구생존기!",
+        image : "https://dn-img-page.kakao.com/download/resource?kid=brEVr3/hzhOkF7eSj/xHW4lqdI3DERYTAhj85wa1&filename=th2",
+        badge : {
+            up : false,
+            new : false,
+            age15 : false
+        },
+        week : "tue",
+        viewer : "17.8만명",
+        writer : "최훈"
+    },
+    {
+        title : "엔젤릭 레이디",
+        description : "나도 네가 불행해졌으면 좋겠어",
+        image : "https://dn-img-page.kakao.com/download/resource?kid=0CvZg/hzb7rxGCIw/rHqCxVFTy4Pci0fwEIEzb0&filename=th2",
+        badge : {
+            up : false,
+            new : false,
+            age15 : false
+        },
+        week : "tue",
+        viewer : "36.9만명",
+        writer : "와플푸, 수수"
+    },
+    {
+        title : "세화, 가는 길",
+        description : "천천히 치유되는 그날의 상처",
+        image : "https://dn-img-page.kakao.com/download/resource?kid=Y1Pyq/hzhOmK0732/Zqtg8dgUDhppRa9vTIS3Ok&filename=th2",
+        badge : {
+            up : false,
+            new : true,
+            age15 : false
+        },
+        week : "wed",
+        viewer : "5.8만명",
+        writer : "한혜연"
+    },
+    {
+        title : "웽툰",
+        description : "바보짓은 웽 때문이야",
+        image : "https://dn-img-page.kakao.com/download/resource?kid=bLZEi9/hyQ9LpEAXn/jsKKjvkGlDhyJZchR7J7z0&filename=th2",
+        badge : {
+            up : true,
+            new : false,
+            age15 : false
+        },
+        week : "wed",
+        viewer : "11.7만명",
+        writer : "황짠느"
+    },
+    {
+        title : "내가 죽였다",
+        description : "누가 아군이고, 누가 적인가.",
+        image : "https://dn-img-page.kakao.com/download/resource?kid=bkuIu6/hzacc29lre/gLKe2nLI4LbBiNviHcwaZK&filename=th2",
+        badge : {
+            up : false,
+            new : false,
+            age15 : true
+        },
+        week : "thu",
+        viewer : "22.1만명",
+        writer : "정오빠,정동생,정해연"
+    },
+    {
+        title : "깨어나세요, 용사여",
+        description : "다섯 남자 중 당신의 취향은?!",
+        image : "https://dn-img-page.kakao.com/download/resource?kid=bIghi4/hzhOiO0RK2/3nk1EZ4lk7oiBKgMUEAhr0&filename=th2",
+        badge : {
+            up : false,
+            new : false,
+            age15 : true
+        },
+        week : "thu",
+        viewer : "49.1만명",
+        writer : "건우건조,아나나스,다나안"
+    },
+    {
+        title : "유리의 벽",
+        description : "그를 만난 순간부터 시작이었다.",
+        image : "https://dn-img-page.kakao.com/download/resource?kid=dmaZLT/hzb7rxhmlz/4UqTzrdzXkui9o6Lgs8CxK&filename=th2",
+        badge : {
+            up : false,
+            new : false,
+            age15 : false
+        },
+        week : "fri",
+        viewer : "44.8만명",
+        writer : "조호"
+    },
+    {
+        title : "아기 황후님",
+        description : "사람들을 구하려면 결혼해야 된다고?",
+        image : "https://dn-img-page.kakao.com/download/resource?kid=chUX1P/hyVkI3H0ff/oBYHB6BQ8ZZCwsdZEfsod0&filename=th2",
+        badge : {
+            up : false,
+            new : false,
+            age15 : false
+        },
+        week : "fri",
+        viewer : "41.6만명",
+        writer : "유소이,마량"
+    },
+    {
+        title : "베이비 드래곤",
+        description : "여고생, 드래곤으로 환생하다!",
+        image : "https://dn-img-page.kakao.com/download/resource?kid=xFknF/hzb7AHmG0T/1Ak5DEmCg4SGLDWauhOsU0&filename=th2",
+        badge : {
+            up : false,
+            new : false,
+            age15 : false
+        },
+        week : "sat",
+        viewer : "33.3만명",
+        writer : "도파라,소홍,캣낫독"
+    },
+    {
+        title : "메모라이즈(MEMORIZE)",
+        description : "그들을, 살리시겠습니까?",
+        image : "https://dn-img-page.kakao.com/download/resource?kid=k4XUx/hyoXzW9UAY/wbX7BSnWm3yF6jNFR7Ft4K&filename=th2",
+        badge : {
+            up : false,
+            new : false,
+            age15 : true
+        },
+        week : "sat",
+        viewer : "35.6만명",
+        writer : "정하,로유진"
+    },
+    {
+        title : "대마법사의 딸",
+        description : "진짜 아빠를 찾아 떠나다!",
+        image : "https://dn-img-page.kakao.com/download/resource?kid=jrIdd/hyQ9TgH4QY/AvsnQkcz862RG6i4Kd6y40&filename=th2",
+        badge : {
+            up : false,
+            new : false,
+            age15 : false
+        },
+        week : "sun",
+        viewer : "104.3만명",
+        writer : "문설아,새벽애"
+    },
+    {
+        title : "그 결혼 제가 할게요",
+        description : "언니, 비켜봐",
+        image : "https://dn-img-page.kakao.com/download/resource?kid=ba9hD3/hyCviayDSb/1YnbHY9pZbhuoPRhhsQTVk&filename=th2",
+        badge : {
+            up : false,
+            new : false,
+            age15 : false
+        },
+        week : "sun",
+        viewer : ".4만명",
+        writer : "갈72치구이,카루목"
+    },
+]
+
+export {topBanner, webtoonData}

--- a/assets/js/data.js
+++ b/assets/js/data.js
@@ -12,15 +12,15 @@ const topBanner = {
             description : "누가 아군이고, 누가 적인가."
         },
         {
-            title : "미슐랭스타",
-            image : "https://dn-img-page.kakao.com/download/resource?kid=bu1cDf/hzp2e5hDx9/kk12ZeaZln5VkyfoC4dfak",
+            title : "로드 오브 머니",
+            image : "https://dn-img-page.kakao.com/download/resource?kid=dfYJhT/hyQ9QDRm4Z/czbknk8mnhG2k7X5MZI2s0",
             badge : {
-                name : "이벤트",
-                src : "https://static-page.kakao.com/static/pc/badge-bigthum-event.svg?2c00fc6eb18517e8f006adfaf464530b",
+                name : "up",
+                src : "https://static-page.kakao.com/static/pc/badge-bigthum-up.svg?a70b9cea4cb6b972e794d199820782a2",
             },
             category : "웹툰",
-            viewer : "59만",
-            description : "최고의 쉐프가 되는건 나야!"
+            viewer : "49.5만",
+            description : "세상에 없던 꼴통 재벌이 되다!"
         }
     ],
     day : [

--- a/assets/js/data.js
+++ b/assets/js/data.js
@@ -21,6 +21,17 @@ const topBanner = {
             category : "웹툰",
             viewer : "49.5만",
             description : "세상에 없던 꼴통 재벌이 되다!"
+        },
+        {
+            title : "지옥에서 돌아온 성좌님",
+            image : "https://dn-img-page.kakao.com/download/resource?kid=vY9EO/hzhOm4DsAe/ooN3xLPLUZPU6Uid2Matlk",
+            badge : {
+                name : "up",
+                src : "https://static-page.kakao.com/static/pc/badge-bigthum-up.svg?a70b9cea4cb6b972e794d199820782a2",
+            },
+            category : "웹툰",
+            viewer : "46.7만",
+            description : "인간 최초의 성좌가 되는 길!"
         }
     ],
     day : [

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,25 +1,26 @@
 import {topBanner} from "./data.js";
 
-const gnb = document.querySelector(".gnb ul");
-const lnb = document.querySelector(".lnb ul");
-const dayNav = document.querySelector(".day_nav ul");
+function clickMenu() {
+    const gnb = document.querySelector(".gnb ul");
+    const lnb = document.querySelector(".lnb ul");
+    const dayNav = document.querySelector(".day_nav ul");
+    
+    gnb.addEventListener("click", (e) => {
+        toActivateNav(e.target, gnb);
+    })
+    
+    lnb.addEventListener("click", (e) => {
+        toActivateNav(e.target, lnb);
+        const targetLnb = e.target.closest('li').getAttribute('data-lnb');
+        changeTopBanner(targetLnb);
+    })
+    
+    dayNav.addEventListener("click", (e) => {
+        toActivateNav(e.target, dayNav);
+    })
 
-gnb.addEventListener("click", (e) => {
-    const eventTarget = e.target;
-    toActivateNav(eventTarget, gnb);
-})
-
-lnb.addEventListener("click", (e) => {
-    const eventTarget = e.target;
-    const targetLnb = eventTarget.closest('li').getAttribute('data-lnb');
-    toActivateNav(eventTarget, lnb);
-    changeTopBanner(targetLnb);
-})
-
-dayNav.addEventListener("click", (e) => {
-    const eventTarget = e.target;
-    toActivateNav(eventTarget, dayNav);
-})
+    lnb.querySelector('li:first-child').click();
+}
 
 function toActivateNav(target, nav) {
     const clickTarget = target.closest('li');
@@ -58,5 +59,5 @@ function creatTopBannerHtml(data) {
 }
 
 (function() {
-    lnb.querySelector('li:first-child').click();
+    clickMenu();
 }())

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -4,26 +4,32 @@ function clickMenu() {
     const gnb = document.querySelector(".gnb ul");
     const lnb = document.querySelector(".lnb ul");
     const dayNav = document.querySelector(".day_nav ul");
+    const topBannerDefault = "home";
+    const dayNavDefault = "mon";
+
     
     gnb.addEventListener("click", (e) => {
+        if(e.target.closest('li').classList.contains('active')) return
         toActivateNav(e.target, gnb);
     })
     
     lnb.addEventListener("click", (e) => {
+        if(e.target.closest('li').classList.contains('active')) return
         toActivateNav(e.target, lnb);
         const targetLnb = e.target.closest('li').getAttribute('data-lnb');
         changeTopBanner(targetLnb);
     })
     
     dayNav.addEventListener("click", (e) => {
+        if(e.target.closest('li').classList.contains('active')) return
         toActivateNav(e.target, dayNav);
         const targetDay = e.target.closest('li').getAttribute('data-day');
         createWebtoonDayContents(targetDay)
 
     })
 
-    lnb.querySelector('li:first-child').click();
-    dayNav.querySelector('li:first-child').click();
+    changeTopBanner(topBannerDefault);
+    createWebtoonDayContents(dayNavDefault)
 }
 
 function toActivateNav(target, nav) {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -30,13 +30,13 @@ function toActivateNav(target, nav) {
 
 function changeTopBanner(targetLnb) {
     const banner = document.querySelector('.top_banner');
-    
     const targetBannerData = topBanner[targetLnb];
-    let itemHtml = '';
+    const itemHtml = targetBannerData.map(data => creatTopBannerHtml(data));
+    banner.querySelector('.slider_items').innerHTML = itemHtml.join();
+}
 
-    targetBannerData.forEach(data => {
-        
-        itemHtml += `
+function creatTopBannerHtml(data) {
+    return `
         <div class="item item_type1">
             <div class="img">
                 <img src="${data.image}" alt="${data.title}">
@@ -55,10 +55,6 @@ function changeTopBanner(targetLnb) {
                 <p class="desc">${data.description}</p>
             </div>
         </div>`;
-    });
-
-
-    banner.querySelector('.slider_items').innerHTML = itemHtml;
 }
 
 (function() {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -44,6 +44,8 @@ function changeTopBanner(targetLnb) {
     const targetBannerData = topBanner[targetLnb];
     const itemHtml = targetBannerData.map(data => creatTopBannerHtml(data));
     banner.querySelector('.slider_items').innerHTML = itemHtml.join('');
+
+    initSlider(banner);
 }
 
 function creatTopBannerHtml(data) {
@@ -119,6 +121,34 @@ function createWebtoonDayContents(targetDay) {
         }
     })
     document.querySelector('.day_contents .item_list').innerHTML = items.join('');
+}
+
+function initSlider(sWrapper) {
+    const sliderWrapper = sWrapper;
+    const sliderBox = sliderWrapper.querySelector('.slider_items');
+    const sliderPager = sliderWrapper.querySelector('.slider_pager');
+    const sliderItem = sliderBox.querySelectorAll('.item');
+    const firstItem = sliderBox.firstElementChild;
+    const lastItem = sliderBox.lastElementChild;
+    const cloneFirst = firstItem.cloneNode(true);
+    const cloneLast = lastItem.cloneNode(true);
+    cloneFirst.classList.add('clone');
+    cloneLast.classList.add('clone');
+    sliderBox.appendChild(cloneFirst);
+    sliderBox.prepend(cloneLast);
+    const itemWidth = 100;
+    let currentIdx = 1;
+    sliderPager.innerText = `${currentIdx} / ${sliderItem.length}`;
+
+    setInitPos(sliderBox, itemWidth);
+    setTimeout(() => {
+        sliderBox.classList.add('animate')
+    }, 0)
+}
+
+function setInitPos(sliderBox, itemWidth) {
+    const initTranslateValue = `-${itemWidth}%` 
+    sliderBox.style.transform = `translateX(${initTranslateValue})`
 }
 
 (function() {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -128,6 +128,7 @@ function initSlider(sWrapper) {
     const sliderBox = sliderWrapper.querySelector('.slider_items');
     const sliderPager = sliderWrapper.querySelector('.slider_pager');
     const sliderItem = sliderBox.querySelectorAll('.item');
+    const itemLength = sliderItem.length;
     const firstItem = sliderBox.firstElementChild;
     const lastItem = sliderBox.lastElementChild;
     const cloneFirst = firstItem.cloneNode(true);
@@ -137,10 +138,10 @@ function initSlider(sWrapper) {
     sliderBox.appendChild(cloneFirst);
     sliderBox.prepend(cloneLast);
     const itemWidth = 100;
-    let currentIdx = 0;
-    let index = 0;
-    sliderPager.innerText = `${currentIdx + 1} / ${sliderItem.length}`;
-
+    const ZERO = 0;
+    let currentIdx = ZERO;
+    let index = ZERO;
+    updatePager(sliderPager, currentIdx, itemLength)
     setInitPos(sliderBox, itemWidth);
     setTimeout(() => {
         sliderBox.classList.add('animate')
@@ -155,17 +156,24 @@ function initSlider(sWrapper) {
             case prevBtn:
                 index = currentIdx - 1;
                 moveSlide(sliderBox, itemWidth, index);
-                currentIdx -= 1;
+                currentIdx -= 1
                 break;
             case nextBtn:
                 index = currentIdx + 1;
                 moveSlide(sliderBox, itemWidth, index)
-                currentIdx += 1;
+                currentIdx += 1
                 break;
             default :
                 break;
         }
-        sliderPager.innerText = `${currentIdx + 1} / ${sliderItem.length}`;
+        
+        updatePager(sliderPager, currentIdx, itemLength)
+
+        if(currentIdx === itemLength) {
+            currentIdx = ZERO
+        }else if(currentIdx < ZERO) {
+            currentIdx = itemLength - 1
+        }
     })
 }
 
@@ -175,8 +183,45 @@ function setInitPos(sliderBox, itemWidth) {
 }
 
 function moveSlide(sliderBox, itemWidth, idx) {
+    const itemLength = sliderBox.querySelectorAll('.item').length - sliderBox.querySelectorAll('.clone').length;
+    const ZERO = 0;
+    const removeTime = 300;
+    const addTime = 400;
     const translateValue = -idx * itemWidth;
     sliderBox.style.marginLeft = `${translateValue}%`
+    
+    if(itemLength === idx) {
+        setTimeout(() => {
+            sliderBox.classList.remove('animate');
+            sliderBox.style.marginLeft = ZERO;
+        }, removeTime)
+        setTimeout(() => {
+            sliderBox.classList.add('animate');
+        }, addTime)
+    } else if(idx < ZERO) {
+        setTimeout(() => {
+            sliderBox.classList.remove('animate');
+            sliderBox.style.marginLeft = `${-itemWidth * (itemLength - 1)}%`;
+        }, removeTime)
+        setTimeout(() => {
+            sliderBox.classList.add('animate');
+        }, addTime)
+    }
+}
+
+function updatePager(pager, currentIdx, itemLength) {
+    const index = currentIdx + 1;
+    const ZERO = 0;
+    const one = 1;
+    const Last = itemLength;
+    
+    if(index > itemLength) {
+        pager.innerText = `${one} / ${itemLength}`;
+    }else if(index === ZERO) {
+        pager.innerText = `${Last} / ${itemLength}`;
+    }else {
+        pager.innerText = `${index} / ${itemLength}`;
+    }
 }
 
 (function() {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -33,7 +33,7 @@ function changeTopBanner(targetLnb) {
     const banner = document.querySelector('.top_banner');
     const targetBannerData = topBanner[targetLnb];
     const itemHtml = targetBannerData.map(data => creatTopBannerHtml(data));
-    banner.querySelector('.slider_items').innerHTML = itemHtml.join();
+    banner.querySelector('.slider_items').innerHTML = itemHtml.join('');
 }
 
 function creatTopBannerHtml(data) {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,4 +1,4 @@
-import {topBanner} from "./data.js";
+import {topBanner, webtoonData} from "./data.js";
 
 function clickMenu() {
     const gnb = document.querySelector(".gnb ul");
@@ -17,9 +17,13 @@ function clickMenu() {
     
     dayNav.addEventListener("click", (e) => {
         toActivateNav(e.target, dayNav);
+        const targetDay = e.target.closest('li').getAttribute('data-day');
+        createWebtoonDayContents(targetDay)
+
     })
 
     lnb.querySelector('li:first-child').click();
+    dayNav.querySelector('li:first-child').click();
 }
 
 function toActivateNav(target, nav) {
@@ -56,6 +60,59 @@ function creatTopBannerHtml(data) {
                 <p class="desc">${data.description}</p>
             </div>
         </div>`;
+}
+
+function getBadge(data) {
+    let badge = '';
+    for(let key in data.badge) {
+        if(data.badge[key]) {
+            switch (key) {
+                case 'up' :
+                    badge += '<img src="./assets/images/ico/badge_up_blue.svg" alt="up">'
+                    break;
+                case 'new' :
+                    badge += '<img src="./assets/images/ico/badge_new_red.svg" alt="새작품"></img>'
+                    break;
+                case 'age15' :
+                    badge += '<img src="./assets/images/ico/badge_15.png" alt="15세 작품">'
+                    break;
+            }
+        }
+    }
+    return badge
+}
+
+function createItemType3Horizontal(data) {
+    const webtoonBadge = getBadge(data)
+    return `<li class="item item_type3 flex horizontal ${data.class || ''}">
+        <a href="#!">
+            <div class="img">
+                <img src="${data.image}" alt="${data.title}">
+            </div>
+            <div class="txt">
+                <div class="item_ttl_box">
+                    <div class="badge">
+                        ${webtoonBadge}
+                    </div>
+                    <h4 class="item_ttl text_ellipsis">${data.title}</h4>
+                </div>
+                <p class="info_txt item_desc text_ellipsis">${data.description}</p>
+                <div class="info">
+                    <span class="info_txt viewer">${data.viewer}</span>
+                    <span class="info_txt text_ellipsis">${data.writer}</span>
+                </div>
+            </div>
+        </a>
+    </li>`
+}
+
+function createWebtoonDayContents(targetDay) {
+    const items = webtoonData.map(data => {
+        if(data.week === targetDay || targetDay === "all") {
+            return createItemType3Horizontal(data);
+        }
+    })
+    document.querySelector('.day_contents .item_list').innerHTML = items.join('');
 }
 
 (function() {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -137,18 +137,46 @@ function initSlider(sWrapper) {
     sliderBox.appendChild(cloneFirst);
     sliderBox.prepend(cloneLast);
     const itemWidth = 100;
-    let currentIdx = 1;
-    sliderPager.innerText = `${currentIdx} / ${sliderItem.length}`;
+    let currentIdx = 0;
+    let index = 0;
+    sliderPager.innerText = `${currentIdx + 1} / ${sliderItem.length}`;
 
     setInitPos(sliderBox, itemWidth);
     setTimeout(() => {
         sliderBox.classList.add('animate')
     }, 0)
+
+    sliderWrapper.addEventListener('click', (e) => {
+        const target = e.target;
+        const prevBtn = sliderWrapper.querySelector('.prev');
+        const nextBtn = sliderWrapper.querySelector('.next');
+    
+        switch (target) {
+            case prevBtn:
+                index = currentIdx - 1;
+                moveSlide(sliderBox, itemWidth, index);
+                currentIdx -= 1;
+                break;
+            case nextBtn:
+                index = currentIdx + 1;
+                moveSlide(sliderBox, itemWidth, index)
+                currentIdx += 1;
+                break;
+            default :
+                break;
+        }
+        sliderPager.innerText = `${currentIdx + 1} / ${sliderItem.length}`;
+    })
 }
 
 function setInitPos(sliderBox, itemWidth) {
     const initTranslateValue = `-${itemWidth}%` 
     sliderBox.style.transform = `translateX(${initTranslateValue})`
+}
+
+function moveSlide(sliderBox, itemWidth, idx) {
+    const translateValue = -idx * itemWidth;
+    sliderBox.style.marginLeft = `${translateValue}%`
 }
 
 (function() {

--- a/index.html
+++ b/index.html
@@ -71,599 +71,27 @@
                 <section class="main_contents">
                     <section class="contents banner top_banner">
                         <div class="slider_items">
-                            <div class="item item_type1">
-                                <div class="img">
-                                    <img src="./assets/images/data/resource.jpg" alt="학사귀환">
-                                </div>
-                                <div class="txt">
-                                    <div class="info_box">
-                                        <h3 class="ttl">학사귀환</h3>
-                                        <div class="info">
-                                            <span class="badge">
-                                                <img src="./assets/images/ico/badge_new.svg" alt="new">
-                                            </span>
-                                            <span class="info_txt cat">웹툰</span>
-                                            <span class="info_txt viewer">2.9만명</span>
-                                        </div>
-                                    </div>
-                                    <p class="desc">학사 마현, 중원으로 돌아오다!</p>
-                                </div>
-                            </div>
+                            
                         </div>
                         <button type="button" class="slider_controller prev">이전</button>
                         <button type="button" class="slider_controller next">다음</button>
                         <div class="slider_pager">1 / 1</div>
                     </section>
-                    <section class="contents sub_nav">
-                        <nav>
-                            <ul>
-                                <li><a href="#!"><span class="sub_nav_ttl text_ellipsis">오늘 UP</span> <span class="num">205</span></a></li>
-                                <li><a href="#!"><span class="sub_nav_ttl text_ellipsis">오늘 신작</span> <span class="num">4</span></a></li>
-                                <li><a href="#!"><span class="sub_nav_ttl text_ellipsis">오리지널</span> <span class="num">2,328</span></a></li>
-                                <li><a href="#!"><span class="sub_nav_ttl text_ellipsis">완결까지 정주행</span></a></li>
-                                <li><a href="#!"><span class="sub_nav_ttl text_ellipsis">독립운동가 웹툰</span></a></li>
-                                <li><a href="#!"><span class="sub_nav_ttl text_ellipsis">오늘 랭킹</span> <span class="num">1위</span></a></li>
-                            </ul>
-                        </nav>
-                    </section>
-                    <section class="contents banner mid_banner">
-                        <div class="slider_box">
-                            <div class="slider_items">
-                                <div class="item">
-                                    <img src="./assets/images/data/mid_resource.png" alt="배너이미지">
-                                </div>
-                            </div>
-                        </div>
-                        <button type="button" class="slider_controller prev">이전</button>
-                        <button type="button" class="slider_controller next">다음</button>
-                    </section>
-                    <section class="contents">
-                        <div class="contents_ttl_box">
-                            <h3 class="contents_ttl">요일 연재 TOP <span class="num">(1,622)</span></h3>
-                            <a href="#!" class="more_btn">더보기</a>
-                        </div>
-                        <nav class="day_nav">
-                            <ul>
-                                <li class="active"><button type="button">월</button></li>
-                                <li><button type="button">화</button></li>
-                                <li><button type="button">수</button></li>
-                                <li><button type="button">목</button></li>
-                                <li><button type="button">금</button></li>
-                                <li><button type="button">토</button></li>
-                                <li><button type="button">일</button></li>
-                                <li><button type="button">완결</button></li>
-                            </ul>
-                        </nav>
-                        <!-- 필터 정렬 -->
-                        <!-- <div class="filter_box filter_type1">
-                            <ul class="cat">
-                                <li class="active"><button type="buton">전체</button></li>
-                                <li><button type="buton">웹툰</button></li>
-                                <li><button type="buton"><img src="./assets/images/ico/ico_wait-off.svg" alt="wait" class="ico_wait">웹툰</button></li>
-                            </ul>
-                            <div class="sort_box">
-                                <button type="button" class="result sort_btn">전체 (167)</button>
-                                <ul class="sort_list">
-                                    <li class="active">전체</li>
-                                    <li>소년</li>
-                                    <li>드라마</li>
-                                    <li>로맨스</li>
-                                    <li>로판</li>
-                                    <li>액션무협</li>
-                                    <li>BL</li>
-                                </ul>
-                            </div>
-                        </div>
-                        <div class="filter_box filter_type2">
-                            <ul class="cat">
-                                <li><button type="buton">전체</button></li>
-                                <li><button type="buton">연재중,완결</button></li>
-                                <li><button type="buton">업데이트순</button></li>
-                                <li><button type="buton">테마키워드</button></li>
-                            </ul>
-                            <div class="result">
-                                <span>1,397 작품</span>
-                            </div>
-                        </div> -->
-                        <ul class="item_list flex col-5">
-                            <li class="item item_type2">
-                                <a href="#!">
-                                    <div class="img">
-                                        <img src="./assets/images/data/item_type2.png" alt="이미지">
-                                        <div class="img_txt">
-                                            <span class="highlight_tt">1위</span>
-                                        </div>
-                                    </div>
-                                    <div class="txt"> 
-                                        <h4 class="item_ttl text_ellipsis">도굴왕</h4>
-                                        <div class="info">
-                                            <div class="badge">
-                                                <img src="./assets/images/ico/badge_up_blue.svg" alt="업데이트">
-                                                <img src="./assets/images/ico/badge_15.png" alt="15세">
-                                            </div>
-                                            <span class="info_txt viewer">200.8만명</span>
-                                        </div>
-                                    </div>
-                                </a>
-                            </li>
-                            <li class="item item_type2">
-                                <a href="#!">
-                                    <div class="img">
-                                        <img src="./assets/images/data/item_type2.png" alt="이미지">
-                                        <div class="img_txt">
-                                            <span class="highlight_tt">1위</span>
-                                        </div>
-                                    </div>
-                                    <div class="txt"> 
-                                        <h4 class="item_ttl text_ellipsis">도굴왕</h4>
-                                        <div class="info">
-                                            <div class="badge">
-                                                <img src="./assets/images/ico/badge_up_blue.svg" alt="업데이트">
-                                                <img src="./assets/images/ico/badge_15.png" alt="15세">
-                                            </div>
-                                            <span class="info_txt viewer">200.8만명</span>
-                                        </div>
-                                    </div>
-                                </a>
-                            </li>
-                            <li class="item item_type2">
-                                <a href="#!">
-                                    <div class="img">
-                                        <img src="./assets/images/data/item_type2.png" alt="이미지">
-                                        <div class="img_txt">
-                                            <span class="highlight_tt">1위</span>
-                                        </div>
-                                    </div>
-                                    <div class="txt"> 
-                                        <h4 class="item_ttl text_ellipsis">도굴왕</h4>
-                                        <div class="info">
-                                            <div class="badge">
-                                                <img src="./assets/images/ico/badge_up_blue.svg" alt="업데이트">
-                                                <img src="./assets/images/ico/badge_15.png" alt="15세">
-                                            </div>
-                                            <span class="info_txt viewer">200.8만명</span>
-                                        </div>
-                                    </div>
-                                </a>
-                            </li>
-                            <li class="item item_type2">
-                                <a href="#!">
-                                    <div class="img">
-                                        <img src="./assets/images/data/item_type2.png" alt="이미지">
-                                        <div class="img_txt">
-                                            <span class="highlight_tt">1위</span>
-                                        </div>
-                                    </div>
-                                    <div class="txt"> 
-                                        <h4 class="item_ttl text_ellipsis">도굴왕</h4>
-                                        <div class="info">
-                                            <div class="badge">
-                                                <img src="./assets/images/ico/badge_up_blue.svg" alt="업데이트">
-                                                <img src="./assets/images/ico/badge_15.png" alt="15세">
-                                            </div>
-                                            <span class="info_txt viewer">200.8만명</span>
-                                        </div>
-                                    </div>
-                                </a>
-                            </li>
-                            <li class="item item_type2">
-                                <a href="#!">
-                                    <div class="img">
-                                        <img src="./assets/images/data/item_type2.png" alt="이미지">
-                                        <div class="img_txt">
-                                            <span class="highlight_tt">1위</span>
-                                        </div>
-                                    </div>
-                                    <div class="txt"> 
-                                        <h4 class="item_ttl text_ellipsis">도굴왕</h4>
-                                        <div class="info">
-                                            <div class="badge">
-                                                <img src="./assets/images/ico/badge_up_blue.svg" alt="업데이트">
-                                                <img src="./assets/images/ico/badge_15.png" alt="15세">
-                                            </div>
-                                            <span class="info_txt viewer">200.8만명</span>
-                                        </div>
-                                    </div>
-                                </a>
-                            </li>
-                            <li class="item item_type2">
-                                <a href="#!">
-                                    <div class="img">
-                                        <img src="./assets/images/data/item_type2.png" alt="이미지">
-                                        <div class="img_txt star">
-                                            <img src="./assets/images/ico/badge-thumbnail-star.svg" alt="평점">
-                                            <span class="highlight_tt star">10.0</span>
-                                        </div>
-                                    </div>
-                                    <div class="txt"> 
-                                        <h4 class="item_ttl text_ellipsis">도굴왕</h4>
-                                        <div class="info">
-                                            <div class="badge">
-                                                <img src="./assets/images/ico/badge_up_blue.svg" alt="업데이트">
-                                                <img src="./assets/images/ico/badge_15.png" alt="15세">
-                                            </div>
-                                            <span class="info_txt viewer">200.8만명</span>
-                                        </div>
-                                    </div>
-                                </a>
-                            </li>
-                            <li class="item item_type2">
-                                <a href="#!">
-                                    <div class="img">
-                                        <img src="./assets/images/data/item_type2.png" alt="이미지">
-                                        <div class="img_txt star">
-                                            <img src="./assets/images/ico/badge-thumbnail-star.svg" alt="평점">
-                                            <span class="highlight_tt star">10.0</span>
-                                        </div>
-                                    </div>
-                                    <div class="txt"> 
-                                        <h4 class="item_ttl text_ellipsis">도굴왕</h4>
-                                        <div class="info">
-                                            <div class="badge">
-                                                <img src="./assets/images/ico/badge_up_blue.svg" alt="업데이트">
-                                                <img src="./assets/images/ico/badge_15.png" alt="15세">
-                                            </div>
-                                            <span class="info_txt viewer">200.8만명</span>
-                                        </div>
-                                    </div>
-                                </a>
-                            </li>
-                            <li class="item item_type2">
-                                <a href="#!">
-                                    <div class="img">
-                                        <img src="./assets/images/data/item_type2.png" alt="이미지">
-                                        <div class="img_txt star">
-                                            <img src="./assets/images/ico/badge-thumbnail-star.svg" alt="평점">
-                                            <span class="highlight_tt star">10.0</span>
-                                        </div>
-                                    </div>
-                                    <div class="txt"> 
-                                        <h4 class="item_ttl text_ellipsis">도굴왕</h4>
-                                        <div class="info">
-                                            <div class="badge">
-                                                <img src="./assets/images/ico/badge_up_blue.svg" alt="업데이트">
-                                                <img src="./assets/images/ico/badge_15.png" alt="15세">
-                                            </div>
-                                            <span class="info_txt viewer">200.8만명</span>
-                                        </div>
-                                    </div>
-                                </a>
-                            </li>
-                            <li class="item item_type2">
-                                <a href="#!">
-                                    <div class="img">
-                                        <img src="./assets/images/data/item_type2.png" alt="이미지">
-                                        <div class="img_txt star">
-                                            <img src="./assets/images/ico/badge-thumbnail-star.svg" alt="평점">
-                                            <span class="highlight_tt star">10.0</span>
-                                        </div>
-                                    </div>
-                                    <div class="txt"> 
-                                        <h4 class="item_ttl text_ellipsis">도굴왕</h4>
-                                        <div class="info">
-                                            <div class="badge">
-                                                <img src="./assets/images/ico/badge_up_blue.svg" alt="업데이트">
-                                                <img src="./assets/images/ico/badge_15.png" alt="15세">
-                                            </div>
-                                            <span class="info_txt viewer">200.8만명</span>
-                                        </div>
-                                    </div>
-                                </a>
-                            </li>
-                            <li class="item item_type2">
-                                <a href="#!">
-                                    <div class="img">
-                                        <img src="./assets/images/data/item_type2.png" alt="이미지">
-                                        <div class="img_txt star">
-                                            <img src="./assets/images/ico/badge-thumbnail-star.svg" alt="평점">
-                                            <span class="highlight_tt star">10.0</span>
-                                        </div>
-                                    </div>
-                                    <div class="txt"> 
-                                        <h4 class="item_ttl text_ellipsis">도굴왕</h4>
-                                        <div class="info">
-                                            <div class="badge">
-                                                <img src="./assets/images/ico/badge_up_blue.svg" alt="업데이트">
-                                                <img src="./assets/images/ico/badge_15.png" alt="15세">
-                                            </div>
-                                            <span class="info_txt viewer">200.8만명</span>
-                                        </div>
-                                    </div>
-                                </a>
-                            </li>
+                    <nav class="day_nav">
+                        <ul>
+                            <li class="active" data-day="mon"><button type="button">월</button></li>
+                            <li data-day="tue"><button type="button">화</button></li>
+                            <li data-day="wed"><button type="button">수</button></li>
+                            <li data-day="thu"><button type="button">목</button></li>
+                            <li data-day="fri"><button type="button">금</button></li>
+                            <li data-day="sat"><button type="button">토</button></li>
+                            <li data-day="sun"><button type="button">일</button></li>
+                            <li data-day="all"><button type="button">전체</button></li>
                         </ul>
-                    </section>
-                    <section class="contents">
-                        <div class="contents_ttl_box">
-                            <h3 class="contents_ttl">기대신작 TOP</h3>
-                            <a href="#!" class="more_btn">더보기</a>
-                        </div>
-                        <ul class="item_list flex col-2">
-                            <li class="item item_type1">
-                                <div class="img">
-                                    <img src="./assets/images/data/item_type1.jpg" alt="화산전쟁">
-                                </div>
-                                <div class="txt">
-                                    <div class="info_box">
-                                        <h4 class="ttl">화산전쟁</h4>
-                                        <div class="info">
-                                            <span class="badge">
-                                                <img src="./assets/images/ico/badge_event.svg" alt="event">
-                                            </span>
-                                            <span class="info_txt cat">웹툰</span>
-                                            <span class="info_txt viewer">183.2만명</span>
-                                        </div>
-                                    </div>
-                                    <p class="desc">나도 그들처럼 영웅이 되고 싶었다.</p>
-                                </div>
-                            </li>
-                        </ul>
-                    </section>
-                    <section class="contents">
-                        <div class="contents_ttl_box">
-                            <h3 class="contents_ttl">로맨스 TOP</h3>
-                            <a href="#!" class="more_btn">더보기</a>
-                        </div>
-                        <ul class="item_list flex col-5">
-                            <li class="item item_type2">
-                                <a href="#!">
-                                    <div class="img">
-                                        <img src="./assets/images/data/item_type2_2.png" alt="이미지">
-                                        <div class="img_txt star">
-                                            <img src="./assets/images/ico/badge-thumbnail-star.svg" alt="평점">
-                                            <span class="highlight_tt star">10.0</span>
-                                        </div>
-                                    </div>
-                                    <div class="txt"> 
-                                        <h4 class="item_ttl text_ellipsis">상사가 나를 덕질한다</h4>
-                                        <div class="info">
-                                            <span class="info_txt viewer">200.8만명</span>
-                                        </div>
-                                    </div>
-                                </a>
-                            </li>
-                            <li class="item item_type2">
-                                <a href="#!">
-                                    <div class="img">
-                                        <img src="./assets/images/data/item_type2_2.png" alt="이미지">
-                                        <div class="img_txt star">
-                                            <img src="./assets/images/ico/badge-thumbnail-star.svg" alt="평점">
-                                            <span class="highlight_tt star">10.0</span>
-                                        </div>
-                                    </div>
-                                    <div class="txt"> 
-                                        <h4 class="item_ttl text_ellipsis">상사가 나를 덕질한다</h4>
-                                        <div class="info">
-                                            <span class="info_txt viewer">200.8만명</span>
-                                        </div>
-                                    </div>
-                                </a>
-                            </li>
-                            <li class="item item_type2">
-                                <a href="#!">
-                                    <div class="img">
-                                        <img src="./assets/images/data/item_type2_2.png" alt="이미지">
-                                        <div class="img_txt star">
-                                            <img src="./assets/images/ico/badge-thumbnail-star.svg" alt="평점">
-                                            <span class="highlight_tt star">10.0</span>
-                                        </div>
-                                    </div>
-                                    <div class="txt"> 
-                                        <h4 class="item_ttl text_ellipsis">상사가 나를 덕질한다</h4>
-                                        <div class="info">
-                                            <span class="info_txt viewer">200.8만명</span>
-                                        </div>
-                                    </div>
-                                </a>
-                            </li>
-                            <li class="item item_type2">
-                                <a href="#!">
-                                    <div class="img">
-                                        <img src="./assets/images/data/item_type2_2.png" alt="이미지">
-                                        <div class="img_txt star">
-                                            <img src="./assets/images/ico/badge-thumbnail-star.svg" alt="평점">
-                                            <span class="highlight_tt star">10.0</span>
-                                        </div>
-                                    </div>
-                                    <div class="txt"> 
-                                        <h4 class="item_ttl text_ellipsis">상사가 나를 덕질한다</h4>
-                                        <div class="info">
-                                            <span class="info_txt viewer">200.8만명</span>
-                                        </div>
-                                    </div>
-                                </a>
-                            </li>
-                            <li class="item item_type2">
-                                <a href="#!">
-                                    <div class="img">
-                                        <img src="./assets/images/data/item_type2_2.png" alt="이미지">
-                                        <div class="img_txt star">
-                                            <img src="./assets/images/ico/badge-thumbnail-star.svg" alt="평점">
-                                            <span class="highlight_tt star">10.0</span>
-                                        </div>
-                                    </div>
-                                    <div class="txt"> 
-                                        <h4 class="item_ttl text_ellipsis">상사가 나를 덕질한다</h4>
-                                        <div class="info">
-                                            <span class="info_txt viewer">200.8만명</span>
-                                        </div>
-                                    </div>
-                                </a>
-                            </li>
-                        </ul>
-                    </section>
-                    <section class="contents">
-                        <div class="contents_ttl_box">
-                            <h3 class="contents_ttl">일간 랭킹 TOP</h3>
-                            <a href="#!" class="more_btn">더보기</a>
-                        </div>
-                        <ol class="item_list">
-                            <li class="item item_type3 flex">
-                                <a href="#!">
-                                    <span class="rank_num">1</span>
-                                    <div class="img">
-                                        <img src="./assets/images/data/item_type3.jpg" alt="흑막을 버리는데 실패했다">
-                                        <div class="img_badge">
-                                            <img src="./assets/images/ico/ico_wait.png" alt="기다리면 무료">
-                                        </div>
-                                    </div>
-                                    <div class="txt">
-                                        <div class="item_ttl_box">
-                                            <div class="badge">
-                                                <img src="./assets/images/ico/badge_new_red.svg" alt="새작품">
-                                                <img src="./assets/images/ico/badge_15.png" alt="15세 작품">
-                                            </div>
-                                            <h4 class="item_ttl text_ellipsis">흑막을 버리는 데 실패했다</h4>
-                                        </div>
-                                        <div class="info">
-                                            <span class="info_txt viewer">28.3만명</span>
-                                            <span class="info_txt">기다무웹툰</span>
-                                            <span class="info_txt">로판</span>
-                                            <span class="info_txt">ASSAM,쓩늉,자은향</span>
-                                        </div>
-                                        <p class="info_txt day_info">수 연재</p>
-                                    </div>
-                                </a>
-                            </li>
-                            <li class="item item_type3 flex">
-                                <a href="#!">
-                                    <span class="rank_num">2</span>
-                                    <div class="img">
-                                        <img src="./assets/images/data/item_type3.jpg" alt="흑막을 버리는데 실패했다">
-                                        <div class="img_badge">
-                                            <img src="./assets/images/ico/ico_wait.png" alt="기다리면 무료">
-                                        </div>
-                                    </div>
-                                    <div class="txt">
-                                        <div class="item_ttl_box">
-                                            <div class="badge">
-                                                <img src="./assets/images/ico/badge_new_red.svg" alt="새작품">
-                                                <img src="./assets/images/ico/badge_15.png" alt="15세 작품">
-                                            </div>
-                                            <h4 class="item_ttl text_ellipsis">흑막을 버리는 데 실패했다</h4>
-                                        </div>
-                                        <div class="info">
-                                            <span class="info_txt viewer">28.3만명</span>
-                                            <span class="info_txt">기다무웹툰</span>
-                                            <span class="info_txt">로판</span>
-                                            <span class="info_txt">ASSAM,쓩늉,자은향</span>
-                                        </div>
-                                        <p class="info_txt day_info">수 연재</p>
-                                    </div>
-                                </a>
-                            </li>
-                            <li class="item item_type3 flex">
-                                <a href="#!">
-                                    <span class="rank_num">3</span>
-                                    <div class="img">
-                                        <img src="./assets/images/data/item_type3.jpg" alt="흑막을 버리는데 실패했다">
-                                        <div class="img_badge">
-                                            <img src="./assets/images/ico/ico_wait.png" alt="기다리면 무료">
-                                        </div>
-                                    </div>
-                                    <div class="txt">
-                                        <div class="item_ttl_box">
-                                            <div class="badge">
-                                                <img src="./assets/images/ico/badge_new_red.svg" alt="새작품">
-                                                <img src="./assets/images/ico/badge_15.png" alt="15세 작품">
-                                            </div>
-                                            <h4 class="item_ttl text_ellipsis">흑막을 버리는 데 실패했다</h4>
-                                        </div>
-                                        <div class="info">
-                                            <span class="info_txt viewer">28.3만명</span>
-                                            <span class="info_txt">기다무웹툰</span>
-                                            <span class="info_txt">로판</span>
-                                            <span class="info_txt">ASSAM,쓩늉,자은향</span>
-                                        </div>
-                                        <p class="info_txt day_info">수 연재</p>
-                                    </div>
-                                </a>
-                            </li>
-                        </ol>
-                    </section>
-                    <section class="contents">
-                        <div class="contents_ttl_box">
-                            <h3 class="contents_ttl">추천 이벤트</h3>
-                            <a href="#!" class="more_btn">더보기</a>
-                        </div>
-                        <div class="banner event_banner">
-                            <div class="slider_items">
-                                <div class="item">
-                                    <img src="./assets/images/data/event.png" alt="학사귀환 이벤트">
-                                </div>
-                            </div>
-                            <div class="control_box">
-                                <button class="slider_controller prev">이전</button>
-                                <span class="slider_pager">1 / 1</span>
-                                <button class="slider_controller next">다음</button>
-                            </div>
-                        </div>
-                    </section>
-                    <section class="contents">
-                        <!-- 웹툰-웹툰 -->
-                        <h3 class="hide">웹툰</h3>
+                    </nav>
+                    <section class="contents day_contents">
                         <ul class="item_list">
-                            <li class="item item_type3 flex horizontal">
-                                <a href="#!">
-                                    <div class="img">
-                                        <img src="./assets/images/data/item_type3_2.png" alt="세화, 가는 길">
-                                    </div>
-                                    <div class="txt">
-                                        <div class="item_ttl_box">
-                                            <div class="badge">
-                                                <img src="./assets/images/ico/badge_new_red.svg" alt="새작품">
-                                                <img src="./assets/images/ico/badge_15.png" alt="15세 작품">
-                                            </div>
-                                            <h4 class="item_ttl text_ellipsis">세화, 가는 길</h4>
-                                        </div>
-                                        <p class="info_txt item_desc text_ellipsis">천천히 치유되는 그날의 상처</p>
-                                        <div class="info">
-                                            <span class="info_txt viewer">28.3만명</span>
-                                            <span class="info_txt">한혜연</span>
-                                        </div>
-                                    </div>
-                                </a>
-                            </li>
-                            <li class="item item_type3 flex horizontal">
-                                <a href="#!">
-                                    <div class="img">
-                                        <img src="./assets/images/data/item_type3_2.png" alt="세화, 가는 길">
-                                    </div>
-                                    <div class="txt">
-                                        <div class="item_ttl_box">
-                                            <div class="badge">
-                                                <img src="./assets/images/ico/badge_up_blue.svg" alt="up">
-                                            </div>
-                                            <h4 class="item_ttl text_ellipsis">세화, 가는 길</h4>
-                                        </div>
-                                        <p class="info_txt item_desc text_ellipsis">천천히 치유되는 그날의 상처</p>
-                                        <div class="info">
-                                            <span class="info_txt viewer">28.3만명</span>
-                                            <span class="info_txt">한혜연</span>
-                                        </div>
-                                    </div>
-                                </a>
-                            </li>
-                            <li class="item item_type3 flex horizontal">
-                                <a href="#!">
-                                    <div class="img">
-                                        <img src="./assets/images/data/item_type3_2.png" alt="세화, 가는 길">
-                                    </div>
-                                    <div class="txt">
-                                        <div class="item_ttl_box">
-                                            <div class="badge">
-                                                <img src="./assets/images/ico/badge_15.png" alt="15세 작품">
-                                            </div>
-                                            <h4 class="item_ttl text_ellipsis">세화, 가는 길</h4>
-                                        </div>
-                                        <p class="info_txt item_desc text_ellipsis">천천히 치유되는 그날의 상처</p>
-                                        <div class="info">
-                                            <span class="info_txt viewer">28.3만명</span>
-                                            <span class="info_txt">한혜연</span>
-                                        </div>
-                                    </div>
-                                </a>
-                            </li>
+                            
                         </ul>
                     </section>
                     <section class="contents">
@@ -675,47 +103,19 @@
                             <li class="item item_type3 flex horizontal">
                                 <a href="#!">
                                     <div class="img">
-                                        <img src="./assets/images/data/item_type3_2.png" alt="세화, 가는 길">
+                                        <img src="https://dn-img-page.kakao.com/download/resource?kid=rQjE3/hzp2l39Lfz/8MWGhF07tZNNjDE8txEzW0&filename=th2" alt="인터넷 중독 캠프">
                                         <div class="img_badge">
                                             <img src="./assets/images/ico/badge_webtoon.png" alt="웹툰 뱃지">
                                         </div>
                                     </div>
                                     <div class="txt">
                                         <div class="item_ttl_box">
-                                            <div class="badge">
-                                                <img src="./assets/images/ico/badge_new_red.svg" alt="새작품">
-                                                <img src="./assets/images/ico/badge_15.png" alt="15세 작품">
-                                            </div>
-                                            <h4 class="item_ttl text_ellipsis">세화, 가는 길</h4>
+                                            <h4 class="item_ttl text_ellipsis">인터넷 중독 캠프</h4>
                                         </div>
-                                        <p class="info_txt item_desc text_ellipsis">천천히 치유되는 그날의 상처</p>
+                                        <p class="info_txt item_desc text_ellipsis">이 캠프의 진짜 목적은..?</p>
                                         <div class="info">
-                                            <span class="info_txt viewer">28.3만명</span>
-                                            <span class="info_txt">한혜연</span>
-                                        </div>
-                                    </div>
-                                </a>
-                            </li>
-                            <li class="item item_type3 flex horizontal crown">
-                                <a href="#!">
-                                    <div class="img">
-                                        <img src="./assets/images/data/item_type3_2.png" alt="세화, 가는 길">
-                                        <div class="img_badge">
-                                            <img src="./assets/images/ico/badge_webtoon.png" alt="웹툰 뱃지">
-                                        </div>
-                                    </div>
-                                    <div class="txt">
-                                        <div class="item_ttl_box">
-                                            <div class="badge">
-                                                <img src="./assets/images/ico/badge_new_red.svg" alt="새작품">
-                                                <img src="./assets/images/ico/badge_15.png" alt="15세 작품">
-                                            </div>
-                                            <h4 class="item_ttl text_ellipsis">세화, 가는 길</h4>
-                                        </div>
-                                        <p class="info_txt item_desc text_ellipsis">천천히 치유되는 그날의 상처</p>
-                                        <div class="info">
-                                            <span class="info_txt viewer">28.3만명</span>
-                                            <span class="info_txt">한혜연</span>
+                                            <span class="info_txt viewer">1.9만명</span>
+                                            <span class="info_txt text_ellipsis">팀 천둥게</span>
                                         </div>
                                     </div>
                                 </a>
@@ -723,119 +123,102 @@
                             <li class="item item_type3 flex horizontal">
                                 <a href="#!">
                                     <div class="img">
-                                        <img src="./assets/images/data/item_type3_2.png" alt="세화, 가는 길">
+                                        <img src="https://dn-img-page.kakao.com/download/resource?kid=17yoQ/hzhOoa0ClK/BokP7kCWJpNlXOSx8fRPuk&filename=th2" alt="리플 : 버서커">
+                                        <div class="img_badge">
+                                            <img src="./assets/images/ico/badge_webtoon.png" alt="웹툰 뱃지">
+                                        </div>
+                                    </div>
+                                    <div class="txt">
+                                        <div class="item_ttl_box">
+                                            <h4 class="item_ttl text_ellipsis">리플 : 버서커</h4>
+                                        </div>
+                                        <p class="info_txt item_desc text_ellipsis">세계 1위 게이머의 화려한 귀환!</p>
+                                        <div class="info">
+                                            <span class="info_txt viewer">7.2만명</span>
+                                            <span class="info_txt text_ellipsis">허니보이</span>
+                                        </div>
+                                    </div>
+                                </a>
+                            </li>
+                            <li class="item item_type3 flex horizontal crown">
+                                <a href="#!">
+                                    <div class="img">
+                                        <img src="https://dn-img-page.kakao.com/download/resource?kid=B9yif/hyoXEYHVNL/gMonAbOI5FKnlnRpgUvmR0&filename=th2" alt="학사재생">
+                                        <div class="img_badge">
+                                            <img src="./assets/images/ico/badge_webtoon.png" alt="웹툰 뱃지">
+                                        </div>
+                                    </div>
+                                    <div class="txt">
+                                        <div class="item_ttl_box">
+                                            <div class="badge">
+                                                <img src="./assets/images/ico/badge_up_blue.svg" alt="up">
+                                            </div>
+                                            <h4 class="item_ttl text_ellipsis">학사재생</h4>
+                                        </div>
+                                        <p class="info_txt item_desc text_ellipsis">금수저를 물고 태어나 버렸다!</p>
+                                        <div class="info">
+                                            <span class="info_txt viewer">167.1만명</span>
+                                            <span class="info_txt text_ellipsis">소유현,윰짝짝</span>
+                                        </div>
+                                    </div>
+                                </a>
+                            </li>
+                            <li class="item item_type3 flex horizontal">
+                                <a href="#!">
+                                    <div class="img">
+                                        <img src="https://dn-img-page.kakao.com/download/resource?kid=n79ft/hywgA9NVsj/sTq4TRecVyVL4cMEKuziO1&filename=th2" alt="FFF급 관심용사">
+                                        <div class="img_badge">
+                                            <img src="./assets/images/ico/badge_webtoon.png" alt="웹툰 뱃지">
+                                        </div>
+                                    </div>
+                                    <div class="txt">
+                                        <div class="item_ttl_box">
+                                            <h4 class="item_ttl text_ellipsis">FFF급 관심용사</h4>
+                                        </div>
+                                        <p class="info_txt item_desc text_ellipsis">10년 개고생했더니, 인성 F등급?!</p>
+                                        <div class="info">
+                                            <span class="info_txt viewer">68.3만명</span>
+                                            <span class="info_txt text_ellipsis">깡무,파르나르</span>
+                                        </div>
+                                    </div>
+                                </a>
+                            </li>
+                            <li class="item item_type3 flex horizontal">
+                                <a href="#!">
+                                    <div class="img">
+                                        <img src="https://dn-img-page.kakao.com/download/resource?kid=FzUnn/hzb7u13KyA/TYj2kYbmToH1v0n6vZwcc1&filename=th2" alt="제19회 대한민국창작만화공모전">
+                                        <div class="img_badge">
+                                            <img src="./assets/images/ico/badge_webtoon.png" alt="웹툰 뱃지">
+                                        </div>
+                                    </div>
+                                    <div class="txt">
+                                        <div class="item_ttl_box">
+                                            <h4 class="item_ttl text_ellipsis">제19회 대한민국창작만화공모전</h4>
+                                        </div>
+                                        <p class="info_txt item_desc text_ellipsis"></p>
+                                        <div class="info">
+                                            <span class="info_txt viewer">1.9만명</span>
+                                            <span class="info_txt text_ellipsis">김휘훈,주혜림(은풀),박혜민,정희정(고요빛),전연홍(이비),박은지(봉봉),김세영,박한나(Hanna),최은혜(EUNHAE)</span>
+                                        </div>
+                                    </div>
+                                </a>
+                            </li>
+                            <li class="item item_type3 flex horizontal">
+                                <a href="#!">
+                                    <div class="img">
+                                        <img src="https://dn-img-page.kakao.com/download/resource?kid=eGLDP/hzhOkswboB/xRaiFtK4AnA308YIF0RkIk&filename=th2" alt="극락왕생">
                                         <div class="img_badge">
                                             <img src="./assets/images/ico/ico_wait.png" alt="웹툰 뱃지">
                                         </div>
                                     </div>
                                     <div class="txt">
-                                        <div class="item_ttl_box">
-                                            <div class="badge">
-                                                <img src="./assets/images/ico/badge_new_red.svg" alt="새작품">
-                                                <img src="./assets/images/ico/badge_15.png" alt="15세 작품">
-                                            </div>
-                                            <h4 class="item_ttl text_ellipsis">세화, 가는 길</h4>
+                                        <div class="item_ttl_box">                                            
+                                            <h4 class="item_ttl text_ellipsis">극락왕생</h4>
                                         </div>
-                                        <p class="info_txt item_desc text_ellipsis">천천히 치유되는 그날의 상처</p>
+                                        <p class="info_txt item_desc text_ellipsis">윤회의 끝, 극락왕생을 위해!</p>
                                         <div class="info">
-                                            <span class="info_txt viewer">28.3만명</span>
-                                            <span class="info_txt">한혜연</span>
-                                        </div>
-                                    </div>
-                                </a>
-                            </li>
-                        </ul>
-                    </section>
-                    <section class="contents">
-                        <div class="contents_ttl_box">
-                            <h3 class="contents_ttl">오늘의 추천</h3>
-                            <a href="#!" class="more_btn">더보기</a>
-                        </div>
-                        <ul class="item_list flex col-4">
-                            <li class="item item_type2 ">
-                                <a href="#!">
-                                    <div class="img">
-                                        <img src="./assets/images/data/item_type3.jpg" alt="흑막을 버리는데 실패했다">
-                                        <div class="img_badge">
-                                            <img src="./assets/images/ico/ico_wait.png" alt="기다리면 무료">
-                                        </div>
-                                    </div>
-                                    <div class="txt">
-                                        <div class="item_ttl_box">
-                                            <div class="badge">
-                                                <img src="./assets/images/ico/badge_new_red.svg" alt="새작품">
-                                                <img src="./assets/images/ico/badge_15.png" alt="15세 작품">
-                                            </div>
-                                            <h4 class="item_ttl text_ellipsis">흑막을 버리는 데 실패했다</h4>
-                                        </div>
-                                        <div class="info">
-                                            <span class="info_txt viewer">28.3만명</span>
-                                        </div>
-                                    </div>
-                                </a>
-                            </li>
-                            <li class="item item_type2 ">
-                                <a href="#!">
-                                    <div class="img">
-                                        <img src="./assets/images/data/item_type3.jpg" alt="흑막을 버리는데 실패했다">
-                                        <div class="img_badge">
-                                            <img src="./assets/images/ico/ico_wait.png" alt="기다리면 무료">
-                                        </div>
-                                    </div>
-                                    <div class="txt">
-                                        <div class="item_ttl_box">
-                                            <div class="badge">
-                                                <img src="./assets/images/ico/badge_new_red.svg" alt="새작품">
-                                                <img src="./assets/images/ico/badge_15.png" alt="15세 작품">
-                                            </div>
-                                            <h4 class="item_ttl text_ellipsis">흑막을 버리는 데 실패했다</h4>
-                                        </div>
-                                        <div class="info">
-                                            <span class="info_txt viewer">28.3만명</span>
-                                        </div>
-                                    </div>
-                                </a>
-                            </li>
-                            <li class="item item_type2 ">
-                                <a href="#!">
-                                    <div class="img">
-                                        <img src="./assets/images/data/item_type3.jpg" alt="흑막을 버리는데 실패했다">
-                                        <div class="img_badge">
-                                            <img src="./assets/images/ico/ico_wait.png" alt="기다리면 무료">
-                                        </div>
-                                    </div>
-                                    <div class="txt">
-                                        <div class="item_ttl_box">
-                                            <div class="badge">
-                                                <img src="./assets/images/ico/badge_new_red.svg" alt="새작품">
-                                                <img src="./assets/images/ico/badge_15.png" alt="15세 작품">
-                                            </div>
-                                            <h4 class="item_ttl text_ellipsis">흑막을 버리는 데 실패했다</h4>
-                                        </div>
-                                        <div class="info">
-                                            <span class="info_txt viewer">28.3만명</span>
-                                        </div>
-                                    </div>
-                                </a>
-                            </li>
-                            <li class="item item_type2 ">
-                                <a href="#!">
-                                    <div class="img">
-                                        <img src="./assets/images/data/item_type3.jpg" alt="흑막을 버리는데 실패했다">
-                                        <div class="img_badge">
-                                            <img src="./assets/images/ico/ico_wait.png" alt="기다리면 무료">
-                                        </div>
-                                    </div>
-                                    <div class="txt">
-                                        <div class="item_ttl_box">
-                                            <div class="badge">
-                                                <img src="./assets/images/ico/badge_new_red.svg" alt="새작품">
-                                                <img src="./assets/images/ico/badge_15.png" alt="15세 작품">
-                                            </div>
-                                            <h4 class="item_ttl text_ellipsis">흑막을 버리는 데 실패했다</h4>
-                                        </div>
-                                        <div class="info">
-                                            <span class="info_txt viewer">28.3만명</span>
+                                            <span class="info_txt viewer">23.7만명</span>
+                                            <span class="info_txt">고사리박사</span>
                                         </div>
                                     </div>
                                 </a>

--- a/index.js
+++ b/index.js
@@ -1,0 +1,14 @@
+const express = require("express");
+const server = express();
+const port = 3000;
+
+server.use(express.static(__dirname + "/"))
+
+server.get("/", (req, res) => {
+    res.sendFile(__dirname + "/index.html");
+})
+
+server.listen(port, (err) => {
+    if (err) return console.log(err);
+    console.log(`The server is listening on port ${port}`);
+})

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "fe-kakaopage",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ju-kkim/fe-kakaopage.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/ju-kkim/fe-kakaopage/issues"
+  },
+  "homepage": "https://github.com/ju-kkim/fe-kakaopage#readme",
+  "dependencies": {
+    "express": "^4.17.3"
+  }
+}


### PR DESCRIPTION
# 카카오 페이지 클론코딩

![kakaopage_tab](https://user-images.githubusercontent.com/68211156/155254763-b3b7adf6-ad00-4b8c-b7c3-56431ee5a030.png)

해당 탭메뉴 클릭시 top banner만 변경됩니다.
컨텐츠 내용은 웹툰 -> 웹툰 내용입니다.

## 추가 구현

- [x] 요일 탭 클릭 - 요일 리스트 가져오기
- [x] express 설치 완료
- [ ] 배너 슬라이드 (아직 미완성입니다.)  
    - 슬라이드를 계속 넘기다 보면 순서가 꼬이는? 버그 발생중입니다.😰   

---
코드가 마음에 들지 않아서 html, css 부터 다 리팩토링 하고싶은 생각이 드는데... 그냥 이어서 하는게 좋을까요..?😭